### PR TITLE
Modify the ways to check regular expressions to fix crashes

### DIFF
--- a/src/Components/ContactInfo.js
+++ b/src/Components/ContactInfo.js
@@ -5,6 +5,7 @@ function ContactInfo({ paymentRequested, passValidation }) {
     if (!paymentRequested && name === '') return;
 
     const LEN = name.length;
+    const MATCHING_LETTERS = name.match(/[a-z ]/gi);
     let msg = '';
 
     switch (true) {
@@ -14,7 +15,7 @@ function ContactInfo({ paymentRequested, passValidation }) {
       case (LEN > 20):
         msg = '최대 20자까지 입력 가능합니다.';
         break;
-      case (LEN !== name.match(/[a-zA-Z ]/g).length):
+      case (!MATCHING_LETTERS || LEN !== MATCHING_LETTERS.length):
         msg = '영어와 띄어쓰기만 입력 가능합니다.';
         break;
       default:

--- a/src/Components/NameEnglish.js
+++ b/src/Components/NameEnglish.js
@@ -5,6 +5,7 @@ function NameEnglish({ paymentRequested, passValidation }) {
     if (!paymentRequested && name === '') return;
 
     const LEN = name.length;
+    const MATCHING_LETTERS = name.match(/[a-z ]/gi);
     let msg = '';
 
     switch (true) {
@@ -14,7 +15,7 @@ function NameEnglish({ paymentRequested, passValidation }) {
       case (LEN > 20):
         msg = '최대 20자까지 입력 가능합니다.';
         break;
-      case (LEN !== name.match(/[a-zA-Z ]/g).length):
+      case (!MATCHING_LETTERS || LEN !== MATCHING_LETTERS.length):
         msg = '영어와 띄어쓰기만 입력 가능합니다.';
         break;
       default:

--- a/src/Components/NameKorean.js
+++ b/src/Components/NameKorean.js
@@ -5,6 +5,7 @@ function NameKorean({ paymentRequested, passValidation }) {
     if (!paymentRequested && name === '') return;
 
     const LEN = name.length;
+    const MATCHING_LETTERS = name.match(/[가-힣]/g);
     let msg = '';
 
     switch (true) {
@@ -14,7 +15,7 @@ function NameKorean({ paymentRequested, passValidation }) {
       case (LEN > 20):
         msg = '최대 20자까지 입력 가능합니다.';
         break;
-      case (LEN !== name.match(/[가-힣]/g).length):
+      case (!MATCHING_LETTERS || LEN !== MATCHING_LETTERS.length):
         msg = '한글만 입력 가능합니다.';
         break;
       default:


### PR DESCRIPTION
- Originally, the app crashed if the user enters only English letters inside the input field designed to get Korean letters, and vice versa